### PR TITLE
fix: Fix architecture mapping for Windows ARM64 in GetCommand

### DIFF
--- a/Devantler.KubeconformCLI.Tests/KubeconformTests/GetCommandTests.cs
+++ b/Devantler.KubeconformCLI.Tests/KubeconformTests/GetCommandTests.cs
@@ -16,7 +16,7 @@ public class GetCommandTests
   [InlineData(PlatformID.Unix, Architecture.X64, "linux-x64", "kubeconform-linux-x64")]
   [InlineData(PlatformID.Unix, Architecture.Arm64, "linux-arm64", "kubeconform-linux-arm64")]
   [InlineData(PlatformID.Win32NT, Architecture.X64, "win-x64", "kubeconform-win-x64.exe")]
-  [InlineData(PlatformID.Win32NT, Architecture.X64, "win-arm64", "kubeconform-win-arm64.exe")]
+  [InlineData(PlatformID.Win32NT, Architecture.Arm64, "win-arm64", "kubeconform-win-arm64.exe")]
   public void GetCommand_ShouldReturnOSXx64Binary(PlatformID platformID, Architecture architecture, string runtimeIdentifier, string expectedBinary)
   {
     // Act

--- a/Devantler.KubeconformCLI/Kubeconform.cs
+++ b/Devantler.KubeconformCLI/Kubeconform.cs
@@ -26,7 +26,7 @@ public static class Kubeconform
       (PlatformID.Unix, Architecture.X64, "linux-x64") => "kubeconform-linux-x64",
       (PlatformID.Unix, Architecture.Arm64, "linux-arm64") => "kubeconform-linux-arm64",
       (PlatformID.Win32NT, Architecture.X64, "win-x64") => "kubeconform-win-x64.exe",
-      (PlatformID.Win32NT, Architecture.X64, "win-arm64") => "kubeconform-win-arm64.exe",
+      (PlatformID.Win32NT, Architecture.Arm64, "win-arm64") => "kubeconform-win-arm64.exe",
       _ => throw new PlatformNotSupportedException($"Unsupported platform: {Environment.OSVersion.Platform} {RuntimeInformation.ProcessArchitecture}"),
     };
     string binaryPath = Path.Combine(AppContext.BaseDirectory, binary);


### PR DESCRIPTION
Correct the architecture mapping for Windows ARM64 to ensure the appropriate binary is returned.