### PR TITLE
fix: Replace Devantler.CLIRunner with CLIWrap for command execution

### DIFF
--- a/src/Devantler.KubeconformCLI/Devantler.KubeconformCLI.csproj
+++ b/src/Devantler.KubeconformCLI/Devantler.KubeconformCLI.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devantler.CLIRunner" Version="1.0.37" />
+    <PackageReference Include="CLIWrap" Version="3.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Devantler.KubeconformCLI/Kubeconform.cs
+++ b/src/Devantler.KubeconformCLI/Kubeconform.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using CliWrap;
+using CliWrap.Buffered;
 using Devantler.CLIRunner;
 
 namespace Devantler.KubeconformCLI;
@@ -57,11 +58,13 @@ public static class Kubeconform
     bool includeStdErr = true,
     CancellationToken cancellationToken = default)
   {
-    return await CLI.RunAsync(
-      Command.WithArguments(arguments),
-      validation: validation,
-      silent: silent,
-      includeStdErr: includeStdErr,
-      cancellationToken: cancellationToken).ConfigureAwait(false);
+    using var stdOut = Console.OpenStandardInput();
+    using var stdErr = Console.OpenStandardError();
+    var command = Command.WithArguments(arguments)
+      .WithValidation(validation)
+      .WithStandardOutputPipe(silent ? PipeTarget.Null : PipeTarget.ToStream(stdOut))
+      .WithStandardErrorPipe(silent || !includeStdErr ? PipeTarget.Null : PipeTarget.ToStream(stdErr));
+    var result = await command.ExecuteBufferedAsync(cancellationToken);
+    return (result.ExitCode, result.StandardOutput + result.StandardError);
   }
 }

--- a/src/Devantler.KubeconformCLI/Kubeconform.cs
+++ b/src/Devantler.KubeconformCLI/Kubeconform.cs
@@ -57,10 +57,12 @@ public static class Kubeconform
     bool includeStdErr = true,
     CancellationToken cancellationToken = default)
   {
-    using var stdOut = Console.OpenStandardInput();
+    using var stdIn = Console.OpenStandardInput();
+    using var stdOut = Console.OpenStandardOutput();
     using var stdErr = Console.OpenStandardError();
     var command = Command.WithArguments(arguments)
       .WithValidation(validation)
+      .WithStandardInputPipe(silent ? PipeSource.Null : PipeSource.FromStream(stdIn))
       .WithStandardOutputPipe(silent ? PipeTarget.Null : PipeTarget.ToStream(stdOut))
       .WithStandardErrorPipe(silent || !includeStdErr ? PipeTarget.Null : PipeTarget.ToStream(stdErr));
     var result = await command.ExecuteBufferedAsync(cancellationToken);

--- a/src/Devantler.KubeconformCLI/Kubeconform.cs
+++ b/src/Devantler.KubeconformCLI/Kubeconform.cs
@@ -1,7 +1,6 @@
 using System.Runtime.InteropServices;
 using CliWrap;
 using CliWrap.Buffered;
-using Devantler.CLIRunner;
 
 namespace Devantler.KubeconformCLI;
 


### PR DESCRIPTION
Switch command execution from Devantler.CLIRunner to CLIWrap, enhancing the command handling and output management.