### PR TITLE
fix: streamline output handling in Kubeconform RunAsync method

### DIFF
--- a/src/Devantler.KubeconformCLI/Kubeconform.cs
+++ b/src/Devantler.KubeconformCLI/Kubeconform.cs
@@ -48,27 +48,21 @@ public static class Kubeconform
   /// <param name="arguments"></param>
   /// <param name="validation"></param>
   /// <param name="silent"></param>
-  /// <param name="includeStdErr"></param>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
   public static async Task<(int ExitCode, string Message)> RunAsync(
     string[] arguments,
     CommandResultValidation validation = CommandResultValidation.ZeroExitCode,
     bool silent = false,
-    bool includeStdErr = true,
     CancellationToken cancellationToken = default)
   {
-    using var stdInConsole = Console.OpenStandardInput();
-    using var stdOutConsole = Console.OpenStandardOutput();
-    using var stdErrConsole = Console.OpenStandardError();
-    var stdOutBuffer = new StringBuilder();
-    var stdErrBuffer = new StringBuilder();
+    using var stdOutConsole = silent ? Stream.Null : Console.OpenStandardOutput();
+    using var stdErrConsole = silent ? Stream.Null : Console.OpenStandardError();
     var command = Command.WithArguments(arguments)
       .WithValidation(validation)
-      .WithStandardInputPipe(PipeSource.FromStream(stdInConsole))
-      .WithStandardOutputPipe(silent ? PipeTarget.ToStringBuilder(stdOutBuffer) : PipeTarget.Merge(PipeTarget.ToStringBuilder(stdOutBuffer), PipeTarget.ToStream(stdOutConsole)))
-      .WithStandardErrorPipe(silent && !includeStdErr ? PipeTarget.ToStringBuilder(stdErrBuffer) : PipeTarget.Merge(PipeTarget.ToStringBuilder(stdErrBuffer), PipeTarget.ToStream(stdErrConsole)));
-    var result = await command.ExecuteAsync(cancellationToken);
-    return (result.ExitCode, stdOutBuffer.ToString() + stdErrBuffer.ToString());
+      .WithStandardOutputPipe(PipeTarget.ToStream(stdOutConsole))
+      .WithStandardErrorPipe(PipeTarget.ToStream(stdErrConsole));
+    var result = await command.ExecuteBufferedAsync(cancellationToken).ConfigureAwait(false);
+    return (result.ExitCode, result.StandardOutput + result.StandardError);
   }
 }


### PR DESCRIPTION
Refactor the output handling in the RunAsync method to simplify the process and improve performance by using buffered execution and removing unnecessary parameters.