### PR TITLE
fix: change Command property to public access modifier

### DIFF
--- a/src/DevantlerTech.KubeconformCLI/Kubeconform.cs
+++ b/src/DevantlerTech.KubeconformCLI/Kubeconform.cs
@@ -11,7 +11,7 @@ public static class Kubeconform
   /// <summary>
   /// The Kubeconform CLI command.
   /// </summary>
-  static Command Command
+  public static Command Command
   {
     get
     {


### PR DESCRIPTION
Change the access modifier of the Command property to public for improved accessibility.